### PR TITLE
[READY] Fix TypeScript unicode tests on Windows

### DIFF
--- a/ycmd/completers/typescript/typescript_completer.py
+++ b/ycmd/completers/typescript/typescript_completer.py
@@ -119,18 +119,12 @@ class TypeScriptCompleter( Completer ):
     # Used to prevent threads from concurrently accessing the sequence counter
     self._sequenceid_lock = Lock()
 
-    # TSServer ignores the fact that newlines are two characters on Windows
-    # (\r\n) instead of one on other platforms (\n), so we use the
-    # universal_newlines option to convert those newlines to \n. See the issue
-    # https://github.com/Microsoft/TypeScript/issues/3403
-    # TODO: remove this option when the issue is fixed.
-    # We also need to redirect the error stream to the output one on Windows.
+    # We need to redirect the error stream to the output one on Windows.
     self._tsserver_handle = utils.SafePopen( binarypath,
-                                             stdout = subprocess.PIPE,
                                              stdin = subprocess.PIPE,
+                                             stdout = subprocess.PIPE,
                                              stderr = subprocess.STDOUT,
-                                             env = self._environ,
-                                             universal_newlines = True )
+                                             env = self._environ )
 
     # Used to map sequence id's to their corresponding DeferredResponse
     # objects. The reader loop uses this to hand out responses.
@@ -174,7 +168,7 @@ class TypeScriptCompleter( Completer ):
             self._pending[ seq ].resolve( message )
             del self._pending[ seq ]
       except Exception as e:
-        _logger.error( 'ReaderLoop error: {0}'.format( str( e ) ) )
+        _logger.exception( e )
 
 
   def _ReadMessage( self ):
@@ -187,7 +181,7 @@ class TypeScriptCompleter( Completer ):
       headerline = self._tsserver_handle.stdout.readline().strip()
       if not headerline:
         break
-      key, value = headerline.split( ':', 1 )
+      key, value = utils.ToUnicode( headerline ).split( ':', 1 )
       headers[ key.strip() ] = value.strip()
 
     # The response message is a JSON object which comes back on one line.
@@ -196,6 +190,13 @@ class TypeScriptCompleter( Completer ):
     if 'Content-Length' not in headers:
       raise RuntimeError( "Missing 'Content-Length' header" )
     contentlength = int( headers[ 'Content-Length' ] )
+    # TSServer adds a newline at the end of the response message and counts it
+    # as one character (\n) towards the content length. However, newlines are
+    # two characters on Windows (\r\n), so we need to take care of that. See
+    # issue https://github.com/Microsoft/TypeScript/issues/3403
+    # TODO: remove this when the issue is fixed.
+    if utils.OnWindows():
+      contentlength += 1
     content = self._tsserver_handle.stdout.readline( contentlength )
     return json.loads( utils.ToUnicode( content ) )
 
@@ -224,7 +225,7 @@ class TypeScriptCompleter( Completer ):
 
     request = json.dumps( self._BuildRequest( command, arguments ) ) + '\n'
     with self._writelock:
-      self._tsserver_handle.stdin.write( request )
+      self._tsserver_handle.stdin.write( utils.ToBytes( request ) )
       self._tsserver_handle.stdin.flush()
 
 
@@ -241,7 +242,7 @@ class TypeScriptCompleter( Completer ):
       seq = request[ 'seq' ]
       self._pending[ seq ] = deferred
     with self._writelock:
-      self._tsserver_handle.stdin.write( json_request )
+      self._tsserver_handle.stdin.write( utils.ToBytes( json_request ) )
       self._tsserver_handle.stdin.flush()
     return deferred.result()
 


### PR DESCRIPTION
See the commit message for the details.

To be fair, it should have be done this way in the first place.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puremourning/ycmd-1/1)

<!-- Reviewable:end -->
