### PR TITLE
[READY] Update unicode tests

### DIFF
--- a/ycmd/tests/completer_test.py
+++ b/ycmd/tests/completer_test.py
@@ -16,6 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with ycmd.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *  # noqa
+
 from ycmd.tests.test_utils import DummyCompleter, ExpectedFailure
 from ycmd.user_options_store import DefaultOptions
 from nose.tools import eq_
@@ -52,8 +60,8 @@ def FilterAndSortCandidates_ServerCompleter_test():
                                   [ { 'insertion_text': 'password' } ] )
 
 
-@ExpectedFailure( 'Filtering uses a bitset which only works for ASCII',
-                  contains_string( 'bitset' ) )
+@ExpectedFailure( 'Filtering does not support unicode characters',
+                  contains_string( '[]' ) )
 def FilterAndSortCandidates_Unicode_test():
   _FilterAndSortCandidates_Match( [ { 'insertion_text': 'ø' } ],
                                   'ø',

--- a/ycmd/tests/get_completions_test.py
+++ b/ycmd/tests/get_completions_test.py
@@ -132,10 +132,9 @@ def GetCompletions_IdentifierCompleter_Unicode_InLine_test( app ):
   )
 
 
-@ExpectedFailure( "The identifier completer - like FilterAndSortCandidates "
-                  "can't handle unicode: "
-                  "https://github.com/Valloric/YouCompleteMe/issues/278",
-                  contains_string( 'bitset' ) )
+@ExpectedFailure( 'The identifier completer does not support '
+                  'unicode characters',
+                  contains_string( '[]' ) )
 @SharedYcmd
 def GetCompletions_IdentifierCompleter_UnicodeQuery_InLine_test( app ):
   contents = """


### PR DESCRIPTION
`FilterAndSortCandidates_Unicode` and `GetCompletions_IdentifierCompleter_UnicodeQuery_InLine` tests now return an empty list of candidates.

You'll need to rebase the unicode investigation branch into master so that the tests pass.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puremourning/ycmd-1/2)

<!-- Reviewable:end -->
