### PR TITLE
Implement GetDoc and GetType

### DIFF
--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -284,8 +284,10 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
 
       # TODO: We should be able to determine the set of things available from
       # the capabilities supplied on initialise
+      'GetDoc': ( lambda self, request_data, args:
+                     self.GetDoc( request_data ) ),
       'GetType': ( lambda self, request_data, args:
-                     self._GetType( request_data ) ),
+                     self.GetType( request_data ) ),
       'GoToDeclaration': ( lambda self, request_data, args:
                              self._GoToDeclaration( request_data ) ),
       'GoTo': ( lambda self, request_data, args:
@@ -312,6 +314,37 @@ class JavaCompleter( language_server_completer.LanguageServerCompleter ):
         'Language server status: {0}'.format( message ) )
 
     return None
+
+
+  def GetType( self, request_data ):
+    hover_response = self._GetHoverResponse( request_data )
+
+    if isinstance( hover_response, list ):
+      if len( hover_response ):
+        get_type_java = hover_response[ 0 ][ 'value' ]
+      else:
+        raise RuntimeError( 'No information' )
+    else:
+      get_type_java = hover_response
+
+    return responses.BuildDisplayMessageResponse( get_type_java )
+
+
+  def GetDoc( self, request_data ):
+    hover_response = self._GetHoverResponse( request_data )
+
+    if isinstance( hover_response, list ):
+      if len( hover_response ):
+        get_doc_java = ''
+        for docstring in hover_response:
+          if not isinstance( docstring, dict ):
+            get_doc_java += docstring + '\n'
+      else:
+        raise RuntimeError( 'No information' )
+    else:
+      get_doc_java = hover_response
+
+    return responses.BuildDisplayMessageResponse( get_doc_java.rstrip() )
 
 
   def HandleServerCommand( self, request_data, command ):

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -675,21 +675,13 @@ class LanguageServerCompleter( Completer ):
         self._syncType ) )
 
 
-  def _GetType( self, request_data ):
+  def _GetHoverResponse( self, request_data ):
     request_id = self.GetServer().NextRequestId()
     response = self.GetServer().GetResponse( request_id,
                                          lsapi.Hover( request_id,
                                                       request_data ) )
 
-    if isinstance( response[ 'result' ][ 'contents' ], list ):
-      if len( response[ 'result' ][ 'contents' ] ):
-        info = response[ 'result' ][ 'contents' ][ 0 ]
-      else:
-        raise RuntimeError( 'No information' )
-    else:
-      info = response[ 'result' ][ 'contents' ]
-
-    return responses.BuildDisplayMessageResponse( str( info ) )
+    return response[ 'result' ][ 'contents' ]
 
 
   def LocationListToGoTo( self, request_data, response ):


### PR DESCRIPTION
GetType is removed from language_server_completer.py since a server is
allowed to return anything upon textDocument/hover request.

GetType and GetDoc are Implemented in java_completer.py with a server
specific modifications to the content of the response to the
textDocument/hover request.