### PR TITLE
Fix filepath to URI conversion on Windows

### DIFF
--- a/ycmd/completers/cpp/clangd_completer.py
+++ b/ycmd/completers/cpp/clangd_completer.py
@@ -19,9 +19,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future import standard_library
-standard_library.install_aliases()
 
 import logging
 import os

--- a/ycmd/completers/java/hook.py
+++ b/ycmd/completers/java/hook.py
@@ -19,8 +19,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
 
 

--- a/ycmd/completers/java/java_completer.py
+++ b/ycmd/completers/java/java_completer.py
@@ -19,9 +19,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future import standard_library
-standard_library.install_aliases()
 
 import logging
 import os

--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -19,11 +19,10 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future import standard_library
-from future.utils import iteritems, iterkeys
-standard_library.install_aliases()
 
+from future.utils import iteritems, iterkeys
 import abc
 import collections
 import logging
@@ -516,7 +515,7 @@ class LanguageServerCompleter( Completer ):
     # of diagnostics.
     # However, we _also_ return them here to refresh diagnostics after, say
     # changing the active file in the editor.
-    uri = lsapi.MakeUriForFile( request_data[ 'filepath' ] )
+    uri = lsapi.FilePathToUri( request_data[ 'filepath' ] )
     if self._latest_diagnostics[ uri ]:
       return [ BuildDiagnostic( request_data, uri, diag )
                for diag in self._latest_diagnostics[ uri ] ]
@@ -737,7 +736,7 @@ class LanguageServerCompleter( Completer ):
       return True
 
     file_diagnostics = self._latest_diagnostics[
-        lsapi.MakeUriForFile( request_data[ 'filepath' ] ) ]
+        lsapi.FilePathToUri( request_data[ 'filepath' ] ) ]
 
     matched_diagnostics = [
       d for d in file_diagnostics if WithinRange( d )

--- a/ycmd/completers/language_server/lsapi.py
+++ b/ycmd/completers/language_server/lsapi.py
@@ -19,17 +19,15 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+# Not installing aliases from python-future; it's unreliable and slow.
 from builtins import *  # noqa
-from future import standard_library
-standard_library.install_aliases()
 
 import os
 import json
-from urllib import parse as urlparse
 
 from collections import defaultdict
-
-from ycmd.utils import ToBytes, ToUnicode
+from ycmd.utils import ( pathname2url, ToBytes, ToUnicode, url2pathname,
+                         urljoin )
 
 
 # FIXME: We might need a whole document management system eventually. For now,
@@ -62,7 +60,7 @@ def Initialise( request_id ):
   return BuildRequest( request_id, 'initialize', {
     'processId': os.getpid(),
     'rootPath': os.getcwd(), # deprecated
-    'rootUri': MakeUriForFile( os.getcwd() ),
+    'rootUri': FilePathToUri( os.getcwd() ),
     'initializationOptions': { },
     'capabilities': { 'trace': 'verbose' }
   } )
@@ -72,7 +70,7 @@ def DidOpenTextDocument( file_name, file_types, file_contents ):
   LAST_VERSION[ file_name ] = LAST_VERSION[ file_name ] + 1
   return BuildNotification( 'textDocument/didOpen', {
     'textDocument': {
-      'uri': MakeUriForFile( file_name ),
+      'uri': FilePathToUri( file_name ),
       'languageId': '/'.join( file_types ),
       'version': LAST_VERSION[ file_name ],
       'text': file_contents
@@ -93,7 +91,7 @@ def DidChangeTextDocument( file_name, file_types, file_contents ):
 def DidCloseTextDocument( file_name ):
   return BuildNotification( 'textDocument/didClose', {
     'textDocument': {
-      'uri': MakeUriForFile( file_name ),
+      'uri': FilePathToUri( file_name ),
       'version': LAST_VERSION[ file_name ],
     },
   } )
@@ -102,7 +100,7 @@ def DidCloseTextDocument( file_name ):
 def Completion( request_id, request_data ):
   return BuildRequest( request_id, 'textDocument/completion', {
     'textDocument': {
-      'uri': MakeUriForFile( request_data[ 'filepath' ] ),
+      'uri': FilePathToUri( request_data[ 'filepath' ] ),
     },
     'position': Position( request_data ),
   } )
@@ -127,7 +125,7 @@ def Definition( request_id, request_data ):
 def CodeAction( request_id, request_data, best_match_range, diagnostics ):
   return BuildRequest( request_id, 'textDocument/codeAction', {
     'textDocument': {
-      'uri': MakeUriForFile( request_data[ 'filepath' ] ),
+      'uri': FilePathToUri( request_data[ 'filepath' ] ),
     },
     'range': best_match_range,
     'context': {
@@ -139,7 +137,7 @@ def CodeAction( request_id, request_data, best_match_range, diagnostics ):
 def Rename( request_id, request_data, new_name ):
   return BuildRequest( request_id, 'textDocument/rename', {
     'textDocument': {
-      'uri': MakeUriForFile( request_data[ 'filepath' ] ),
+      'uri': FilePathToUri( request_data[ 'filepath' ] ),
     },
     'position': Position( request_data ),
   } )
@@ -148,7 +146,7 @@ def Rename( request_id, request_data, new_name ):
 def BuildTextDocumentPositionParams( request_data ):
   return {
     'textDocument': {
-      'uri': MakeUriForFile( request_data[ 'filepath' ] ),
+      'uri': FilePathToUri( request_data[ 'filepath' ] ),
     },
     'position': Position( request_data ),
   }
@@ -168,15 +166,13 @@ def Position( request_data ):
   }
 
 
-def MakeUriForFile( file_name ):
-  return 'file://{0}'.format( file_name )
+def FilePathToUri( file_name ):
+  return urljoin( 'file:', pathname2url( file_name ) )
 
 
 def UriToFilePath( uri ):
-  # NOTE: This assumes file://
-  # TODO(Ben): work out how urlparse works with __future__
-  # TODO(Ben): doesn't work on Windows (probably)
-  return urlparse.urlparse( uri ).path
+  # NOTE: This assumes the URI starts with file:
+  return url2pathname( uri[ 5 : ] )
 
 
 def _BuildMessageData( message ):

--- a/ycmd/utils.py
+++ b/ycmd/utils.py
@@ -33,15 +33,18 @@ import tempfile
 import time
 
 
-# Idiom to import urljoin and urlparse on Python 2 and 3. By exposing these
-# functions here, we can import them directly from this module:
+# Idiom to import pathname2url, url2pathname, urljoin, and urlparse on Python 2
+# and 3. By exposing these functions here, we can import them directly from this
+# module:
 #
-#   from ycmd.utils import urljoin, urlparse
+#   from ycmd.utils import pathname2url, url2pathname, urljoin, urlparse
 #
 if PY2:
   from urlparse import urljoin, urlparse
+  from urllib import pathname2url, url2pathname
 else:
   from urllib.parse import urljoin, urlparse  # noqa
+  from urllib.request import pathname2url, url2pathname  # noqa
 
 
 # Creation flag to disable creating a console window on Windows. See


### PR DESCRIPTION
As you suspected, the Java completer wasn't working on Windows because the filepath to URI conversion (and the reverse operation) was incorrect on this platform. This is fixed by using the `pathname2url` and `url2patname` functions from `urllib` on Python 2 and `urllib.request` on Python 3.

Remove the lines:
```python
from future import standard_library
standard_library.install_aliases()
```
from the new files as we don't need them anymore since PR https://github.com/Valloric/ycmd/pull/722.

Rename `MakeUriForFile` to `FilePathToUri` for consistency with the reverse function `UriToFilePath`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puremourning/ycmd-1/6)
<!-- Reviewable:end -->
