### PR TITLE
Start jdt.ls on FileReadyToParse event

### DIFF
--- a/ycmd/completers/language_server/language_server_completer.py
+++ b/ycmd/completers/language_server/language_server_completer.py
@@ -985,16 +985,16 @@ class LanguageServerCompleter( Completer ):
           del self._serverFileState[ file_name ]
 
 
-  def _GetProjectDirectory( self ):
+  def _GetProjectDirectory( self, request_data ):
     """Return the directory in which the server should operate. Language server
     protocol and most servers have a concept of a 'project directory'. By
-    default this is the working directory of the ycmd server, but
+    default this is the filepath directory of the initial request, but
     implementations may override this for example if there is a language- or
     server-specific notion of a project that can be detected."""
-    return utils.GetCurrentDirectory()
+    return os.path.dirname( request_data[ 'filepath' ] )
 
 
-  def SendInitialize( self ):
+  def SendInitialize( self, request_data ):
     """Sends the initialize request asynchronously.
     This must be called immediately after establishing the connection with the
     language server. Implementations must not issue further requests to the
@@ -1005,7 +1005,8 @@ class LanguageServerCompleter( Completer ):
       assert not self._initialize_response
 
       request_id = self.GetConnection().NextRequestId()
-      msg = lsp.Initialize( request_id, self._GetProjectDirectory() )
+      msg = lsp.Initialize( request_id,
+                            self._GetProjectDirectory( request_data  ) )
 
       def response_handler( response, message ):
         if message is None:

--- a/ycmd/tests/client_test.py
+++ b/ycmd/tests/client_test.py
@@ -32,10 +32,8 @@ import os
 import psutil
 import requests
 import subprocess
-import shutil
 import sys
 import time
-import tempfile
 
 from ycmd.hmac_utils import CreateHmac, CreateRequestHmac, SecureBytesEqual
 from ycmd.tests import PathToTestFile
@@ -71,10 +69,6 @@ class Client_test( object ):
     self._options_dict[ 'hmac_secret' ] = ToUnicode(
       b64encode( self._hmac_secret ) )
 
-    self._orig_working_dir = os.getcwd()
-    self._working_dir = tempfile.mkdtemp()
-    os.chdir( self._working_dir )
-
 
   def tearDown( self ):
     for server in self._servers:
@@ -83,9 +77,6 @@ class Client_test( object ):
     CloseStandardStreams( self._popen_handle )
     for logfile in self._logfiles:
       RemoveIfExists( logfile )
-
-    os.chdir( self._orig_working_dir )
-    shutil.rmtree( self._working_dir )
 
 
   def Start( self, idle_suicide_seconds = 60,

--- a/ycmd/tests/java/diagnostics_test.py
+++ b/ycmd/tests/java/diagnostics_test.py
@@ -28,11 +28,11 @@ from hamcrest import assert_that, contains, contains_inanyorder, has_entries
 from nose.tools import eq_
 
 from ycmd.tests.java import ( DEFAULT_PROJECT_DIR,
-                              IsolatedYcmdInDirectory,
+                              IsolatedYcmd,
                               PathToTestFile,
                               PollForMessages,
                               SharedYcmd,
-                              WaitUntilCompleterServerReady )
+                              StartJavaCompleterServerInDirectory )
 
 from ycmd.tests.test_utils import BuildRequest, LocationMatcher
 from ycmd.utils import ReadFile
@@ -191,9 +191,10 @@ def FileReadyToParse_Diagnostics_Simple_test( app ):
   assert_that( results, DIAG_MATCHERS_PER_FILE[ filepath ] )
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( DEFAULT_PROJECT_DIR ) )
+@IsolatedYcmd
 def FileReadyToParse_Diagnostics_FileNotOnDisk_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( DEFAULT_PROJECT_DIR ) )
 
   contents = '''
     package com.test;

--- a/ycmd/tests/java/server_management_test.py
+++ b/ycmd/tests/java/server_management_test.py
@@ -33,9 +33,11 @@ from hamcrest import ( assert_that,
                        has_entry,
                        has_item )
 from ycmd.tests.java import ( PathToTestFile,
-                              IsolatedYcmdInDirectory,
-                              WaitUntilCompleterServerReady )
-from ycmd.tests.test_utils import BuildRequest, TemporaryTestDir
+                              IsolatedYcmd,
+                              StartJavaCompleterServerInDirectory )
+from ycmd.tests.test_utils import ( BuildRequest,
+                                    TemporaryTestDir,
+                                    WaitUntilCompleterServerReady )
 from ycmd import utils
 
 
@@ -75,9 +77,10 @@ def TidyJDTProjectFiles( dir_name ):
   return decorator
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( 'simple_eclipse_project' ) )
+@IsolatedYcmd
 def ServerManagement_RestartServer_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory(
+    app, PathToTestFile( 'simple_eclipse_project' ) )
 
   eclipse_project = PathToTestFile( 'simple_eclipse_project' )
   maven_project = PathToTestFile( 'simple_maven_project' )
@@ -106,7 +109,7 @@ def ServerManagement_RestartServer_test( app ):
     ),
   )
 
-  WaitUntilCompleterServerReady( app )
+  WaitUntilCompleterServerReady( app, 'java' )
 
   app.post_json(
     '/event_notification',
@@ -124,9 +127,10 @@ def ServerManagement_RestartServer_test( app ):
                _ProjectDirectoryMatcher( maven_project ) )
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( 'simple_eclipse_project', 'src' ) )
+@IsolatedYcmd
 def ServerManagement_ProjectDetection_EclipseParent_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory(
+    app, PathToTestFile( 'simple_eclipse_project', 'src' ) )
 
   project = PathToTestFile( 'simple_eclipse_project' )
 
@@ -137,14 +141,15 @@ def ServerManagement_ProjectDetection_EclipseParent_test( app ):
 
 
 @TidyJDTProjectFiles( PathToTestFile( 'simple_maven_project' ) )
-@IsolatedYcmdInDirectory( PathToTestFile( 'simple_maven_project',
-                                          'src',
-                                          'main',
-                                          'java',
-                                          'com',
-                                          'test' ) )
+@IsolatedYcmd
 def ServerManagement_ProjectDetection_MavenParent_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( 'simple_maven_project',
+                                                       'src',
+                                                       'main',
+                                                       'java',
+                                                       'com',
+                                                       'test' ) )
 
   project = PathToTestFile( 'simple_maven_project' )
 
@@ -155,14 +160,15 @@ def ServerManagement_ProjectDetection_MavenParent_test( app ):
 
 
 @TidyJDTProjectFiles( PathToTestFile( 'simple_maven_project' ) )
-@IsolatedYcmdInDirectory( PathToTestFile( 'simple_gradle_project',
-                                          'src',
-                                          'main',
-                                          'java',
-                                          'com',
-                                          'test' ) )
+@IsolatedYcmd
 def ServerManagement_ProjectDetection_GradleParent_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( 'simple_gradle_project',
+                                                       'src',
+                                                       'main',
+                                                       'java',
+                                                       'com',
+                                                       'test' ) )
 
   project = PathToTestFile( 'simple_gradle_project' )
 
@@ -175,51 +181,30 @@ def ServerManagement_ProjectDetection_GradleParent_test( app ):
 def ServerManagement_ProjectDetection_NoParent_test():
   with TemporaryTestDir() as tmp_dir:
 
-    @IsolatedYcmdInDirectory( tmp_dir )
+    @IsolatedYcmd
     def Test( app ):
-      WaitUntilCompleterServerReady( app )
+      StartJavaCompleterServerInDirectory( app, tmp_dir )
 
       # Run the debug info to check that we have the correct project dir (cwd)
       request_data = BuildRequest( filetype = 'java' )
       assert_that( app.post_json( '/debug_info', request_data ).json,
-                   _ProjectDirectoryMatcher( os.path.realpath( tmp_dir ) ) )
+                   _ProjectDirectoryMatcher( tmp_dir ) )
 
     yield Test
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( 'simple_eclipse_project' ) )
+@IsolatedYcmd
 @patch( 'ycmd.completers.java.java_completer.JavaCompleter.ShutdownServer',
         side_effect = AssertionError )
 def ServerManagement_CloseServer_Unclean_test( app,
                               stop_server_cleanly ):
-  WaitUntilCompleterServerReady( app )
-
-  filepath = PathToTestFile( 'simple_maven_project',
-                             'src',
-                             'main',
-                             'java',
-                             'com',
-                             'test',
-                             'TestFactory.java' )
-
-  app.post_json(
-    '/event_notification',
-    BuildRequest(
-      filepath = filepath,
-      filetype = 'java',
-      working_dir = PathToTestFile( 'simple_eclipse_project' ),
-      event_name = 'FileReadyToParse',
-    )
-  )
-
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory(
+    app, PathToTestFile( 'simple_eclipse_project' ) )
 
   app.post_json(
     '/run_completer_command',
     BuildRequest(
-      filepath = filepath,
       filetype = 'java',
-      working_dir = PathToTestFile( 'simple_eclipse_project' ),
       command_arguments = [ 'StopServer' ],
     ),
   )

--- a/ycmd/tests/java/subcommands_test.py
+++ b/ycmd/tests/java/subcommands_test.py
@@ -35,11 +35,11 @@ import requests
 
 from ycmd.utils import ReadFile
 from ycmd.completers.java.java_completer import NO_DOCUMENTATION_MESSAGE
-from ycmd.tests.java import ( PathToTestFile,
+from ycmd.tests.java import ( DEFAULT_PROJECT_DIR,
+                              IsolatedYcmd,
+                              PathToTestFile,
                               SharedYcmd,
-                              IsolatedYcmdInDirectory,
-                              WaitUntilCompleterServerReady,
-                              DEFAULT_PROJECT_DIR )
+                              StartJavaCompleterServerInDirectory )
 from ycmd.tests.test_utils import ( BuildRequest,
                                     ChunkMatcher,
                                     ErrorMatcher,
@@ -105,9 +105,10 @@ def RunTest( app, test, contents = None ):
   assert_that( response.json, test[ 'expect' ][ 'data' ] )
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( DEFAULT_PROJECT_DIR  ) )
+@IsolatedYcmd
 def Subcommands_GetDoc_NoDoc_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( DEFAULT_PROJECT_DIR ) )
   filepath = PathToTestFile( 'simple_eclipse_project',
                              'src',
                              'com',
@@ -184,9 +185,10 @@ def Subcommands_GetDoc_Class_test( app ):
   } )
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( DEFAULT_PROJECT_DIR  ) )
+@IsolatedYcmd
 def Subcommands_GetType_NoKnownType_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( DEFAULT_PROJECT_DIR ) )
   filepath = PathToTestFile( 'simple_eclipse_project',
                              'src',
                              'com',
@@ -415,9 +417,10 @@ def Subcommands_GetType_LiteralValue_test( app ):
                ErrorMatcher( RuntimeError, 'Unknown type' ) )
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( DEFAULT_PROJECT_DIR  ) )
+@IsolatedYcmd
 def Subcommands_GoTo_NoLocation_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( DEFAULT_PROJECT_DIR ) )
   filepath = PathToTestFile( 'simple_eclipse_project',
                              'src',
                              'com',
@@ -443,9 +446,10 @@ def Subcommands_GoTo_NoLocation_test( app ):
                ErrorMatcher( RuntimeError, 'Cannot jump to location' ) )
 
 
-@IsolatedYcmdInDirectory( PathToTestFile( DEFAULT_PROJECT_DIR  ) )
+@IsolatedYcmd
 def Subcommands_GoToReferences_NoReferences_test( app ):
-  WaitUntilCompleterServerReady( app )
+  StartJavaCompleterServerInDirectory( app,
+                                       PathToTestFile( DEFAULT_PROJECT_DIR ) )
   filepath = PathToTestFile( 'simple_eclipse_project',
                              'src',
                              'com',


### PR DESCRIPTION
As discussed on Gitter, start jdt.ls on the `FileReadyToParse` event so that we can use the filepath from the request to find the project directory and pass that directory to the server. Make sure that we only try to start the server once. Fix Python subprocesses coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puremourning/ycmd-1/12)
<!-- Reviewable:end -->
