### PR TITLE
[READY] One more test

### DIFF
--- a/ycmd/completers/completer.py
+++ b/ycmd/completers/completer.py
@@ -232,9 +232,6 @@ class Completer( with_metaclass( abc.ABCMeta, object ) ):
     if self.user_options[ 'disable_signature_help' ]:
       return False
 
-    if not self.signature_triggers:
-      return False
-
     state = request_data.get( 'signature_help_state', 'INACTIVE' )
 
     current_line = request_data[ 'line_value' ]

--- a/ycmd/tests/language_server/generic_completer_test.py
+++ b/ycmd/tests/language_server/generic_completer_test.py
@@ -273,3 +273,33 @@ def GenericLSPCompleter_SignatureHelp_NoTriggers_test( app ):
     } ),
     'errors': empty()
   } ) )
+
+
+@IsolatedYcmd( { 'language_server':
+  [ { 'name': 'foo',
+      'filetypes': [ 'foo' ],
+      'project_root_files': [ 'proj_root' ],
+      'cmdline': [ 'node', PATH_TO_GENERIC_COMPLETER, '--stdio' ] } ] } )
+@patch( 'ycmd.completers.completer.Completer.ShouldUseSignatureHelpNow',
+        return_value = True )
+def GenericLSPCompleter_SignatureHelp_NotASigHelpProvider_test( app, *args ):
+  test_file = PathToTestFile(
+      'generic_server', 'foo', 'bar', 'baz', 'test_file' )
+  request = BuildRequest( filepath = test_file,
+                          filetype = 'foo',
+                          line_num = 1,
+                          column_num = 1,
+                          contents = '',
+                          event_name = 'FileReadyToParse' )
+  app.post_json( '/event_notification', request )
+  WaitUntilCompleterServerReady( app, 'foo' )
+  request.pop( 'event_name' )
+  response = app.post_json( '/signature_help', request ).json
+  assert_that( response, has_entries( {
+    'signature_help': has_entries( {
+      'activeSignature': 0,
+      'activeParameter': 0,
+      'signatures': empty()
+    } ),
+    'errors': empty()
+  } ) )


### PR DESCRIPTION
Two changes actually. One test because I missed a non-covered line.

The other change is in `completer_utils`. `PreparedTriggers` is a custom class, so `bool(PreparedTriggers)` is always `True` and that's why I couldn't hit the `if not self.signature_triggers:` line. I might be missing something, but I don't think so. If I am missing something, how come `GenericLSPCompleter_SignatureHelp_NoTriggers_test` won't hit the line above? If I am not missing anything, how come `if not self.completion_triggers:` is hit by our tests? Too much mocking?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puremourning/ycmd-1/22)
<!-- Reviewable:end -->
