### PR TITLE
[READY] Run the tests without /shutdown_servers

### DIFF
--- a/ycmd/handlers.py
+++ b/ycmd/handlers.py
@@ -293,16 +293,6 @@ def Shutdown():
   return _JsonResponse( True )
 
 
-
-@app.post( '/shutdown_servers' )
-def ShutdownSubservers():
-  LOGGER.info( 'Received ***test only*** shutdown servers request' )
-  ServerCleanup()
-
-  return _JsonResponse( True )
-
-
-
 @app.post( '/receive_messages' )
 def ReceiveMessages():
   # Receive messages is a "long-poll" handler.

--- a/ycmd/tests/clang/conftest.py
+++ b/ycmd/tests/clang/conftest.py
@@ -18,8 +18,7 @@
 import pytest
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
                                     IsolatedApp,
-                                    SetUpApp,
-                                    ShutdownSubservers )
+                                    SetUpApp )
 
 shared_app = None
 
@@ -28,8 +27,6 @@ shared_app = None
 def set_up_shared_app():
   global shared_app
   shared_app = SetUpApp( { 'use_clangd': 0 } )
-  yield
-  ShutdownSubservers( shared_app )
 
 
 @pytest.fixture
@@ -41,7 +38,6 @@ def app( request ):
     custom_options.update( { 'use_clangd': 0 } )
     with IsolatedApp( custom_options ) as app:
       yield app
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/clangd/conftest.py
+++ b/ycmd/tests/clangd/conftest.py
@@ -21,8 +21,7 @@ from ycmd.tests.test_utils import ( ClearCompletionsCache,
                                     IgnoreExtraConfOutsideTestsFolder,
                                     IsolatedApp,
                                     SetUpApp,
-                                    StopCompleterServer,
-                                    ShutdownSubservers )
+                                    StopCompleterServer )
 from ycmd.completers.cpp import clangd_completer
 shared_app = None
 
@@ -33,7 +32,6 @@ def set_up_shared_app():
   shared_app = SetUpApp()
   yield
   StopCompleterServer( shared_app, 'cpp' )
-  ShutdownSubservers( shared_app )
 
 
 @pytest.fixture
@@ -45,7 +43,6 @@ def app( request ):
       clangd_completer.CLANGD_COMMAND = clangd_completer.NOT_CACHED
       yield app
       StopCompleterServer( app, 'cpp' )
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/conftest.py
+++ b/ycmd/tests/conftest.py
@@ -18,8 +18,7 @@
 import pytest
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
                                     IsolatedApp,
-                                    SetUpApp,
-                                    ShutdownSubservers )
+                                    SetUpApp )
 
 shared_app = None
 
@@ -28,8 +27,6 @@ shared_app = None
 def set_up_shared_app():
   global shared_app
   shared_app = SetUpApp()
-  yield
-  ShutdownSubservers( shared_app )
 
 
 @pytest.fixture
@@ -39,7 +36,6 @@ def app( request ):
   if which == 'isolated':
     with IsolatedApp( request.param[ 1 ] ) as app:
       yield app
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/cs/conftest.py
+++ b/ycmd/tests/cs/conftest.py
@@ -27,8 +27,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     IsolatedApp,
                                     WaitUntilCompleterServerReady,
                                     StopCompleterServer,
-                                    SetUpApp,
-                                    ShutdownSubservers )
+                                    SetUpApp )
 
 shared_app = None
 # map of 'app' to filepaths
@@ -44,7 +43,6 @@ def set_up_shared_app():
   for filepath in shared_filepaths.get( shared_app, [] ):
     StopCompleterServer( shared_app, 'cs', filepath )
 
-  ShutdownSubservers( shared_app )
 
 
 @pytest.fixture
@@ -59,7 +57,6 @@ def app( request ):
       for filepath in shared_filepaths.get( app, [] ):
         StopCompleterServer( app, 'cs', filepath )
 
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/go/conftest.py
+++ b/ycmd/tests/go/conftest.py
@@ -23,8 +23,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     IsolatedApp,
                                     SetUpApp,
                                     StopCompleterServer,
-                                    WaitUntilCompleterServerReady,
-                                    ShutdownSubservers )
+                                    WaitUntilCompleterServerReady )
 shared_app = None
 
 
@@ -36,7 +35,6 @@ def set_up_shared_app():
     StartGoCompleterServerInDirectory( shared_app, PathToTestFile() )
   yield
   StopCompleterServer( shared_app, 'go' )
-  ShutdownSubservers( shared_app )
 
 
 def StartGoCompleterServerInDirectory( app, directory ):
@@ -56,7 +54,6 @@ def app( request ):
     with IsolatedApp( {} ) as app:
       yield app
       StopCompleterServer( app, 'go' )
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/java/conftest.py
+++ b/ycmd/tests/java/conftest.py
@@ -24,8 +24,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     IsolatedApp,
                                     SetUpApp,
                                     StopCompleterServer,
-                                    WaitUntilCompleterServerReady,
-                                    ShutdownSubservers )
+                                    WaitUntilCompleterServerReady )
 shared_app = None
 SERVER_STARTUP_TIMEOUT = 120 # seconds
 
@@ -46,7 +45,6 @@ def set_up_shared_app():
         shared_app, PathToTestFile( DEFAULT_PROJECT_DIR ) )
   yield
   StopCompleterServer( shared_app, 'java' )
-  ShutdownSubservers( shared_app )
 
 
 def StartJavaCompleterServerInDirectory( app, directory ):
@@ -82,7 +80,6 @@ def isolated_app():
         yield app
       finally:
         StopCompleterServer( app, 'java' )
-        ShutdownSubservers( app )
 
   return manager
 
@@ -95,7 +92,6 @@ def app( request ):
     with IsolatedApp( request.param[ 1 ] ) as app:
       yield app
       StopCompleterServer( app, 'java' )
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/javascript/conftest.py
+++ b/ycmd/tests/javascript/conftest.py
@@ -24,8 +24,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     IsolatedApp,
                                     SetUpApp,
                                     StopCompleterServer,
-                                    WaitUntilCompleterServerReady,
-                                    ShutdownSubservers )
+                                    WaitUntilCompleterServerReady )
 shared_app = None
 
 
@@ -38,7 +37,6 @@ def set_up_shared_app():
     WaitUntilCompleterServerReady( shared_app, 'javascript' )
   yield
   StopCompleterServer( shared_app, 'typescript' )
-  ShutdownSubservers( shared_app )
 
 
 def StartGoCompleterServerInDirectory( app, directory ):
@@ -61,7 +59,6 @@ def app( request ):
       with IsolatedApp( request.param[ 1 ] ) as app:
         yield app
         StopCompleterServer( app, 'go' )
-        ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/python/conftest.py
+++ b/ycmd/tests/python/conftest.py
@@ -20,8 +20,7 @@ import pytest
 from ycmd.tests.test_utils import ( ClearCompletionsCache,
                                     IgnoreExtraConfOutsideTestsFolder,
                                     IsolatedApp,
-                                    SetUpApp,
-                                    ShutdownSubservers )
+                                    SetUpApp )
 
 shared_app = None
 
@@ -30,8 +29,6 @@ shared_app = None
 def set_up_shared_app():
   global shared_app
   shared_app = SetUpApp()
-  yield
-  ShutdownSubservers( shared_app )
 
 
 @pytest.fixture
@@ -41,10 +38,7 @@ def app( request ):
   if which == 'isolated':
     custom_options = request.param[ 1 ]
     with IsolatedApp( custom_options ) as app:
-      try:
-        yield app
-      finally:
-        ShutdownSubservers( app )
+      yield app
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/rust/conftest.py
+++ b/ycmd/tests/rust/conftest.py
@@ -23,8 +23,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     IsolatedApp,
                                     SetUpApp,
                                     StopCompleterServer,
-                                    WaitUntilCompleterServerReady,
-                                    ShutdownSubservers )
+                                    WaitUntilCompleterServerReady )
 shared_app = None
 
 
@@ -37,7 +36,6 @@ def set_up_shared_app():
                                          PathToTestFile( 'common', 'src' ) )
   yield
   StopCompleterServer( shared_app, 'rust' )
-  ShutdownSubservers( shared_app )
 
 
 def StartRustCompleterServerInDirectory( app, directory ):
@@ -57,7 +55,6 @@ def app( request ):
     with IsolatedApp( {} ) as app:
       yield app
       StopCompleterServer( app, 'rust' )
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/tern/conftest.py
+++ b/ycmd/tests/tern/conftest.py
@@ -19,8 +19,7 @@ import os
 import pytest
 from ycmd.tests.test_utils import ( BuildRequest, ClearCompletionsCache,
                                     IsolatedApp, SetUpApp, StopCompleterServer,
-                                    WaitUntilCompleterServerReady,
-                                    ShutdownSubservers )
+                                    WaitUntilCompleterServerReady )
 shared_app = None
 
 
@@ -35,7 +34,6 @@ def set_up_shared_app():
   StartJavaScriptCompleterServerInDirectory( shared_app, PathToTestFile() )
   yield
   StopCompleterServer( shared_app, 'java' )
-  ShutdownSubservers( shared_app )
 
 
 def StartJavaScriptCompleterServerInDirectory( app, directory ):
@@ -55,7 +53,6 @@ def app( request ):
     with IsolatedApp( {} ) as app:
       yield app
       StopCompleterServer( app, 'javascript' )
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()

--- a/ycmd/tests/test_utils.py
+++ b/ycmd/tests/test_utils.py
@@ -239,10 +239,6 @@ def SetUpApp( custom_options = {} ):
   return TestApp( handlers.app )
 
 
-def ShutdownSubservers( app ):
-  app.post( '/shutdown_servers', expect_errors=True )
-
-
 @contextlib.contextmanager
 def IgnoreExtraConfOutsideTestsFolder():
   with patch( 'ycmd.utils.IsRootDirectory',

--- a/ycmd/tests/typescript/conftest.py
+++ b/ycmd/tests/typescript/conftest.py
@@ -23,8 +23,7 @@ from ycmd.tests.test_utils import ( BuildRequest,
                                     IsolatedApp,
                                     SetUpApp,
                                     StopCompleterServer,
-                                    WaitUntilCompleterServerReady,
-                                    ShutdownSubservers )
+                                    WaitUntilCompleterServerReady )
 shared_app = None
 
 
@@ -35,7 +34,6 @@ def set_up_shared_app():
   WaitUntilCompleterServerReady( shared_app, 'typescript' )
   yield
   StopCompleterServer( shared_app, 'typescript' )
-  ShutdownSubservers( shared_app )
 
 
 def StartGoCompleterServerInDirectory( app, directory ):
@@ -55,7 +53,6 @@ def app( request ):
     with IsolatedApp( request.param[ 1 ] ) as app:
       yield app
       StopCompleterServer( app, 'go' )
-      ShutdownSubservers( app )
   else:
     global shared_app
     ClearCompletionsCache()


### PR DESCRIPTION
I tested a patch that instantly returns `True` on `/shutdown_servers` and it worked, but I'd still wait for the tests to finish before merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puremourning/ycmd-1/26)
<!-- Reviewable:end -->
